### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ main, master ]
   workflow_dispatch:  # Allows manual triggering
+permissions:
+  contents: read
 jobs:
   # Build job for Jekyll site
   build-pages-site:


### PR DESCRIPTION
Potential fix for [https://github.com/cypress-exe/InfiniBot/security/code-scanning/1](https://github.com/cypress-exe/InfiniBot/security/code-scanning/1)

To address the issue, the workflow needs explicit permissions defined to restrict the GITHUB_TOKEN to the least privilege required for each job. At the root level, a `permissions` block can be added to set the default permissions for all jobs. Alternatively, permissions can be defined individually for each job if different levels of access are required.

In this case, both jobs (`build-pages-site` and `run-tests`) appear to require only read access to the repository contents. Therefore, a `permissions` block with `contents: read` can be added at the root level for simplicity, ensuring all jobs default to this minimal privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
