### PR TITLE
docs: Added community standards files to repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,83 @@
+name: 🐛 Bug Report
+description: Report something that isn't working as expected.
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the
+        sections below as completely as you can; it helps us reproduce
+        and fix the issue faster.
+
+        If this is a **security vulnerability**, please do not file it
+        here (see [SECURITY.md](https://github.com/cypress-exe/InfiniBot/blob/main/SECURITY.md) instead).
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues to make sure this isn't a duplicate.
+          required: true
+        - label: I'm using the latest version of InfiniBot (or `main`, if self-hosting).
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+      placeholder: What happened? What did you expect to happen instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Step-by-step instructions to reproduce the behavior.
+      placeholder: |
+        1. Run command '...'
+        2. Configure setting '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs / Screenshots
+      description: Paste any relevant error output, stack traces, or screenshots. This will be rendered as code automatically.
+      render: shell
+
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment
+      description: Are you using the official InfiniBot, or self-hosting?
+      options:
+        - Official InfiniBot (invited to my server)
+        - Self-hosted
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version / Commit
+      description: If self-hosting, which commit or version are you running? (`pyproject.toml` version, or `git rev-parse HEAD`)
+      placeholder: e.g. v4.1.1 or a1b2c3d
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment (self-hosted only)
+      description: OS, Docker version, and any relevant environment details.
+      placeholder: e.g. Ubuntu 24.04, Docker 27.0.3
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Anything else that might help us understand the issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🔒 Report a Security Vulnerability
+    url: https://github.com/cypress-exe/InfiniBot/security/advisories/new
+    about: Please report security vulnerabilities privately; do not open a public issue.
+  - name: 💬 Discord Support Server
+    url: https://discord.gg/mWgJJ8ZqwR
+    about: General questions, help with setup, or discussion before filing an issue.
+  - name: 📖 Documentation
+    url: https://cypress-exe.github.io/InfiniBot/
+    about: User-facing docs on installation, configuration, and commands.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,67 @@
+name: 💡 Feature Request
+description: Suggest a new feature or improvement for InfiniBot.
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! For larger features, it's
+        worth discussing here before opening a pull request, so we can
+        make sure it fits the project's direction.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues to make sure this isn't a duplicate.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Motivation
+      description: What problem does this feature solve, or what's currently missing/annoying?
+      placeholder: e.g. "There's currently no way to..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe what you'd like to see happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions, workarounds, or existing features you've considered.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of InfiniBot does this relate to?
+      options:
+        - Moderation / Anti-spam
+        - Leveling / XP
+        - Welcome / Leave messages
+        - Reaction roles
+        - Birthdays
+        - Entertainment / Fun commands
+        - Configuration / Admin settings
+        - Performance / Scaling
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Mockups, examples from other bots, or anything else useful.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+## Description
+
+<!-- What does this PR change, and why? -->
+
+## Related Issue(s)
+
+<!-- e.g. Fixes #123, Relates to #456 -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Performance / refactor (no functional change)
+
+## How Has This Been Tested?
+
+<!-- Describe the tests you ran and/or added. Include relevant commands, e.g. `./run_tests.bash` -->
+
+## Checklist
+
+- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines.
+- [ ] My changes follow the existing code style in the files I touched.
+- [ ] I have added/updated tests that prove my fix is effective or my feature works.
+- [ ] I have updated relevant documentation in `./documentation` (if applicable).
+- [ ] `./run_tests.bash` passes locally.
+- [ ] Any derivative/modified code remains open source, per the project [LICENSE](../LICENSE).
+
+## Additional Notes
+
+<!-- Anything reviewers should know: tradeoffs, follow-up work, screenshots, etc. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+# Contributing to InfiniBot
+
+Thanks for your interest in improving InfiniBot! This document covers how to
+get set up, the expected workflow, and what makes a good pull request.
+
+## Before you start
+
+- **Bug fixes and small improvements** - feel free to open a PR directly.
+- **New features or larger changes** - please open an issue first to
+  discuss the approach. This avoids wasted effort on something that might
+  not fit the project's direction.
+- Check existing [issues](https://github.com/cypress-exe/InfiniBot/issues)
+  and [pull requests](https://github.com/cypress-exe/InfiniBot/pulls) to
+  avoid duplicating work.
+- Review the [license](LICENSE) usage terms before contributing derivative
+  work. In particular, InfiniBot may not be used to run a competing public
+  bot service.
+
+## Development setup
+
+InfiniBot runs inside Docker. See the [README](README.md#-quick-start) for
+full setup instructions. In short:
+
+```bash
+git clone https://github.com/cypress-exe/InfiniBot.git
+cd InfiniBot
+sudo bash build.bash
+sudo bash run.bash        # will error until you set DISCORD_AUTH_TOKEN in .env
+sudo bash rebuild_and_run.bash
+```
+
+Dependencies are managed with [uv](https://docs.astral.sh/uv/) and pinned in
+`pyproject.toml` / `uv.lock`. The project targets Python 3.13+.
+
+Developer documentation for internal systems (database, config, event
+harness, etc.) lives in the `./documentation` folder.
+
+## Making changes
+
+1. Fork the repository and create a feature branch off `main`:
+   ```bash
+   git checkout -b feature/short-description
+   ```
+2. Make your changes, keeping commits focused and scoped to a single
+   purpose.
+3. Follow the existing code style in the file you're editing rather than
+   introducing a new convention.
+4. Add or update tests where behavior changes (see below).
+5. Update relevant docs in `./documentation` if you change internal
+   architecture, config, or developer-facing behavior.
+
+## Running tests
+
+Tests run inside the Docker container:
+
+```bash
+./run_tests.bash
+```
+
+Useful flags:
+- `--skip-build` - reuse the existing container image instead of rebuilding.
+- `--run-all` - run the full test suite (used in CI).
+
+CI (`.github/workflows/ci.yml`) builds the Docker image and runs the test
+suite on every push and pull request to `main`. Please make sure tests pass
+locally before opening a PR.
+
+## Submitting a pull request
+
+1. Push your branch and open a PR against `main`.
+2. Fill out the pull request template, including a clear description of
+   **what** changed and **why**.
+3. Link any related issues (e.g. `Fixes #123`).
+4. Ensure CI is passing. PRs with failing checks generally won't be
+   reviewed until fixed.
+5. Be responsive to review feedback. Small, iterative PRs are easier to
+   merge than large ones that sit open.
+
+## Reporting bugs and requesting features
+
+Use [GitHub Issues](https://github.com/cypress-exe/InfiniBot/issues) with
+the appropriate template. For security vulnerabilities, do **not** open a
+public issue (see [SECURITY.md](SECURITY.md) instead).
+
+## Questions
+
+Join the [InfiniBot Discord server](https://discord.gg/mWgJJ8ZqwR) if you
+want to discuss an idea before writing code, or need help getting your dev
+environment running.
+
+## Source Disclosure
+This document was generated with Claude Sonnet 5 and reviewed/edited by cypress.exe.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,60 @@
+# Security Policy
+
+## Supported Versions
+
+InfiniBot is deployed as a single rolling release rather than maintained
+across multiple version branches. Only the latest version on the `main`
+branch (as run by the official InfiniBot service) receives security fixes.
+
+| Version         | Supported          |
+| --------------- | ------------------- |
+| Latest (`main`) | :white_check_mark:  |
+| Older releases  | :x:                  |
+
+If you're self-hosting, please stay up to date with `main` to receive
+security patches.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub
+issues, discussions, or the Discord server.**
+
+Instead, please report them using one of the following private channels:
+
+1. **GitHub Security Advisories (preferred)** - Use the
+   [Report a vulnerability](https://github.com/cypress-exe/InfiniBot/security/advisories/new)
+   form on this repository. This creates a private advisory visible only to
+   maintainers until it's resolved.
+2. **Direct message on Discord** - Contact `cypress.exe` directly on the
+   [InfiniBot support server](https://discord.gg/mWgJJ8ZqwR) if you don't
+   have GitHub access or need a faster response.
+
+When reporting, please include as much of the following as you can:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce, or a proof of concept
+- The affected component (e.g. a specific cog, the config system, the
+  Docker setup) and version/commit hash
+- Any suggested remediation, if you have one
+
+## What to expect
+
+- We aim to acknowledge reports within a few days.
+- We'll keep you updated as we investigate and work on a fix.
+- Once a fix is released, we'll credit you in the release notes (unless you
+  prefer to remain anonymous).
+- Please give us reasonable time to address the issue before any public
+  disclosure.
+  + If the issue is not addressed **within 90 days**, you may disclose it publicly.
+
+## Scope
+
+This policy covers the InfiniBot bot codebase in this repository. It does not 
+cover third-party dependencies directly (please report those upstream) but let 
+us know if a dependency vulnerability affects InfiniBot specifically, as we 
+may need to update our pinned version.
+
+Thank you for helping keep InfiniBot and its users safe.
+
+## Source Disclosure
+This document was generated with Claude Sonnet 5 and reviewed/edited by cypress.exe.


### PR DESCRIPTION
Added:
- **CONTRIBUTING.md**: setup via Docker/uv, workflow expectations, test instructions (./run_tests.bash), PR process
- **SECURITY.md**: private reporting via GitHub Security Advisories or Discord DM, no public issue filing for vulns
- **.github/ISSUE_TEMPLATE/bug_report.yml** + **feature_request.yml** + **config.yml**: (disables blank issues, adds security/Discord/docs links)
- **.github/PULL_REQUEST_TEMPLATE.md**: checklist tied to your license's open-source requirement and test script