### PR TITLE
Fix view/modal leak and disable startup chunking (scale plan items 2 & 3)

### DIFF
--- a/documentation/scale_performance_assessment_2026-07.md
+++ b/documentation/scale_performance_assessment_2026-07.md
@@ -9,6 +9,14 @@ validation from the synthetic event harness and a progress log.
 Updated 2026-07-04 by Anthropic Claude Opus 4.8 via Claude Code (CLI): marked plan item 1
 (JSONFile in-memory cache) done; implementation was written by hand and reviewed/verified
 by Claude. Recorded the before/after harness benchmark results (proportions only).
+Updated 2026-07-04 by Anthropic Claude Sonnet 5 via Claude Code (CLI): marked plan items 2
+(view/modal leak) and 3 (startup chunking) done. Implementation was scripted (AST-based
+audit + automated edits for the ~130 View/Modal timeout fixes) and hand-written for the
+chunking/raw-event changes, then reviewed by Claude Fable 5 across three passes (one
+in-repo review, one GitHub Copilot review, one live-crash triage) with fixes applied by
+Claude Sonnet 5. Also fixed an unrelated nextcord 3.2.0 regression that surfaced once the
+bot was actually run (see section 5), and added a `-memory` admin command field for the
+view/modal store counts this section recommends watching.
 -->
 
 # InfiniBot Scale & Performance Assessment (July 2026)
@@ -66,6 +74,37 @@ unchunked cache.
    everything at runtime anyway.
 3. Accept (or work around) the missed *first* nickname-change event per uncached member
    in the nickname profanity check.
+
+**Update (2026-07-04): done.** `chunk_guilds_at_startup=False` in `src/core/bot.py`, and
+the `ensure_guilds_ready()` retry-chunking function was deleted outright (not just its
+call site) — it existed purely to retry full-guild REST chunking after boot, and leaving
+it in would have silently reintroduced the same boot-time cost via a different path now
+that every guild starts unchunked. All three required changes above were made:
+`on_member_remove` → `on_raw_member_remove` (with `autobans.member_has_autoban`,
+`leveling.handle_member_removal`, and `join_leave_messages.trigger_leave_message`
+refactored to take `guild`/IDs directly, since the raw event's `payload.user` is a plain
+`nextcord.User`, not a `Member` — the member has already left by the time the raw event
+fires); the two `on_raw_message_edit`/`on_raw_message_delete` chunk() calls were removed;
+and the nickname-check chunk() call in `moderation.check_and_punish_nickname_for_profanity`
+was also removed (same anti-pattern, same fix, not originally called out above but caught
+during implementation) with a code comment recording the accepted first-event-miss
+limitation. One additional runtime chunk() call in `action_logging.log_member_removal`
+(unrelated to the two named above, found during implementation) was removed for the same
+reason. Three other `guild.chunk()` sites were deliberately left alone as out of scope:
+`ui_components.chunk_guild_with_feedback` (explicit user-facing command flow),
+`reaction_roles.py:340`, and a different function in `moderation.py` — none of these run
+on a hot, high-frequency path the way the removed ones did.
+
+One follow-on fix was needed for correctness rather than performance: with chunking
+disabled, an edited message's author can resolve to a plain `User` instead of a `Member`,
+which made `on_raw_message_edit`'s profanity check on edited messages silently skip
+uncached authors. Fixed with a single-member lookup (`utils.get_member()`, cache hit or
+REST fetch-on-miss) before the moderation check, rather than either skipping the check or
+reintroducing a full guild chunk.
+
+**Not yet re-measured:** actual boot time / RSS before-vs-after in production. The harness
+(section 6) doesn't cover this — it exercises event handling, not startup — so this still
+needs a real restart to confirm the "well under a minute" prediction.
 
 **Note on "store chunk data in the DB and restore on boot":** stale by construction —
 members join/leave while the bot is offline, and staleness hits exactly the paths that
@@ -146,6 +185,54 @@ in `init_views()` (`src/core/view_manager.py`).
 **Verification:** log `len(bot._connection._view_store._views)` (e.g. from an admin
 command) and watch it grow under load before the fix, plateau after.
 
+**Update (2026-07-04): done.** An AST-based audit script enumerated every View/Modal
+subclass in `src/` (137 classes), and an automated line-based edit script set
+`timeout=300` (5 min) on all of them except: the 10 persistent views registered via
+`bot.add_view()` in `init_views()` (unchanged, still `timeout=None`, correct), and 7
+decorative link-button-only views in `ui_components.py` (`SupportView`, `InviteView`,
+etc.) that have zero dispatchable items and so are never added to `ViewStore._views`
+regardless of timeout. A follow-up manual review pass caught two inline
+`CustomView(timeout=None)` instantiations in `dashboard.py` that the class-based AST
+audit missed (constructed directly, not as their own class) — those were fixed too.
+`self.stop()` was already present in the genuinely terminal callbacks (e.g.
+`purging.ConfirmationView`); nothing further was needed there. One cosmetic gap: the
+default `on_timeout` leaves buttons enabled, so a view that times out (rather than being
+explicitly stopped) will show Discord's generic "This interaction failed" on the next
+click instead of a friendlier disabled state — not a leak, just polish for later.
+
+**Verification, implemented:** `-memory` (level 2 admin command) now reports **Active
+Views** and **Modals** alongside RSS/thread/cache stats (`src/components/memory_profiler.py`,
+`src/features/admin_commands.py`).
+
+**Correction (2026-07-04), found while dogfooding the metric itself:** the first version
+of this counted `len(bot._connection._view_store.all_views())` directly, which looked
+static (e.g. stuck at 22 views/1 modal across ~20 minutes of `-memory` polling on a test
+server) and read as "the timeout isn't working." It wasn't the timeout — it was the
+metric. `ViewStore.all_views()`/`_modal_store._modals` return everything in nextcord's
+internal dict regardless of whether each entry has actually finished; nextcord only
+sweeps *finished* entries out of that dict as a side effect of `add_view()`/`dispatch()`
+being called again for something else entirely. A view can time out correctly
+(`view.is_finished()` flips to `True` right on schedule) and then sit in the raw dict
+indefinitely if no further view-related activity happens to trigger a sweep — reproduced
+directly: a view with `timeout=0.5` genuinely expired (`is_finished() == True`) but
+`len(all_views())` stayed at 1 with no other activity in-process. The command now reports
+both **Active** (filtered by `not is_finished()` — the number that actually answers "is
+this still pinned in memory") and a parenthetical **unswept in store** count (raw dict
+size, expected to run ahead of Active and not itself evidence of a leak). Watch **Active**
+under load — that's the one that should plateau, not grow unbounded. Not yet observed
+under real sustained production load.
+
+The same command also now reports **Chunked Guilds** (`X/Y`, via `guild.chunked` across
+`bot.guilds` — the section 1 metric: with startup chunking disabled this should stay well
+below the total most of the time, climbing only as guilds get lazily chunked through
+normal activity or the few remaining explicit `guild.chunk()` call sites), **Cached
+Members** (sum of `len(guild.members)` across all guilds — the ~500k-member concern from
+section 1), **Cached Users** (`len(bot._connection._users)`, nextcord's global user cache:
+DM users, message authors, mentions, etc. — distinct from per-guild members), and **Cached
+Messages (nextcord)** (`len(bot.cached_messages)`, nextcord's own bounded `max_messages=1000`
+cache, separate from InfiniBot's DB-backed message cache already shown as "Cached Messages
+(DB)").
+
 ### Swept and (mostly) clean
 
 `tz_cache` (bounded TTLCache), `ExpiringSet` (purges on access), message cache
@@ -202,6 +289,57 @@ PR #10166, [Umbra's CV2 guide](about.abstractumbra.dev/discord.py/2025/08/17/com
 - Table/column names f-string-interpolated into SQL throughout `db_manager.py` —
   internal-only today, but fragile.
 - `on_ready` re-entrancy on reconnects (see §3).
+- `src/features/onboarding.py:59-64` — a bare `raise` inside a `try` (with no exception
+  in flight) is used deliberately to force entry into the `except:` block, as a crude
+  way to pick `send_message` vs `edit_message`. Works (the `RuntimeError` it raises
+  becomes the "active exception"), but it's a trap for the next reader and produces a
+  confusing chained traceback in logs. Found 2026-07-04 while triaging the regression
+  below; not the cause of it. Worth a straight `if/else` rewrite.
+- `src/modules/custom_types.py` — `ExpiringSet` never had a `remove()` method despite
+  `server_join_and_leave_manager.py` calling `.remove()` on every guild rejoin
+  (`recently_left_guilds.remove(guild.id)`), which would `AttributeError` on every
+  rejoin. Added the method (2026-07-04) as a safe no-op-if-absent pop, so a
+  check-then-remove caller can't race the set's own TTL-based expiry.
+
+### 2026-07-04 regression, unrelated to this document's plan: nextcord 3.2.0 breaks all string selects
+
+Independent of everything above: the `nextcord` dependency was bumped `3.1.1 → 3.2.0` in
+a prior PR (#69, merged the day before this was found). In 3.2.0,
+`nextcord.ui.Select`/`StringSelect` passes `custom_id=MISSING` down to its base class by
+default, but the base class's custom-id auto-generation only fires `if custom_id is
+None` — so `MISSING` slips through, the select serializes with no `custom_id`, and
+Discord 400s with `Invalid Form Body: components.N.components.N.custom_id: This field
+is required`. This broke **every** string select in the bot (14 sites, including the
+ones behind the persistent role-message views) the first time each was actually
+rendered in production — none of it is caught by the unit test suite, which doesn't
+exercise Discord's API or component serialization. Fixed by passing an explicit
+`custom_id` at all 14 sites, which bypasses the broken default (verified empirically:
+`Select(...).to_component_dict()['custom_id']` is `None` without an explicit id, set
+correctly with one). No nextcord version change needed, so 3.2.0's Components V2
+support (§4) is retained.
+
+### 2026-07-04, same bug class, InfiniBot's own code this time: `CustomModal` leaked `dataclasses.MISSING` as a `custom_id`
+
+Found while testing the view/modal timeout work: opening the Leveling → Level-Up Message
+modal (and, by construction, any `CustomModal`) crashed with
+`TypeError: Object of type _MISSING_TYPE is not JSON serializable` from inside
+`send_modal`. Root cause: `src/components/ui_components.py` imported `MISSING` from the
+standard library's `dataclasses` module (`from dataclasses import MISSING`) and used it
+as `CustomModal.__init__`'s default for a pass-through `custom_id` parameter. nextcord's
+own `Modal.__init__` decides whether to auto-generate a `custom_id` with
+`custom_id = os.urandom(16).hex() if custom_id is MISSING else custom_id` — checking
+identity against **its own** `nextcord.utils.MISSING` singleton. Since
+`dataclasses.MISSING` is a different object entirely, that check is always `False`, so
+nextcord took the `else` branch and set `self.custom_id` to the literal
+`dataclasses.MISSING` sentinel — which then failed to serialize when the modal was sent.
+Every `CustomModal` subclass was affected (none of them pass `custom_id` explicitly, so
+all hit the broken default), which is effectively all ~35 Modal subclasses in the
+codebase. Reproduced directly (`dataclasses.MISSING` fails the same `is` check and
+produces byte-for-byte the same `json.dumps` error) and fixed with a one-line import
+change to `from nextcord.utils import MISSING` — confirmed the auto-generated
+`custom_id` and full JSON payload are correct afterward. Not caught by the test suite for
+the same reason as the section 5 regression above: no test exercises modal
+serialization against Discord's actual request-shape expectations.
 
 ---
 
@@ -247,8 +385,8 @@ snapshot) before and after each change.
 | --- | --- | --- | --- | --- |
 | 0 | Synthetic event harness + prod-snapshot benchmarking (§6) | — | Baseline & regression metric for everything below | ✅ Done (PR #70) |
 | 1 | In-memory cache for `JSONFile` config reads (invalidate on write; `GlobalSetting` API unchanged) | ~1 day | ~99% of hot-path file I/O; most prod flakiness | ✅ Done (2026-07-04) |
-| 2 | Fix view/modal leak (finite timeouts, `stop()` in terminal callbacks) | ~1–2 days | OOM crash | Next up |
-| 3 | Disable startup chunking + raw-event migration (§1) | ~1–2 days | Boot time; GBs of RSS | Not started |
+| 2 | Fix view/modal leak (finite timeouts, `stop()` in terminal callbacks) | ~1–2 days | OOM crash | ✅ Done (2026-07-04) |
+| 3 | Disable startup chunking + raw-event migration (§1) | ~1–2 days | Boot time; GBs of RSS | ✅ Done (2026-07-04) |
 | 4 | Per-guild settings cache: one `SELECT *` per table per guild in a `TTLCache(maxsize≈5000)`, invalidated on write | ~2–3 days | Remaining hot-path queries | Not started |
 | 5 | Wrap residual DB calls in `asyncio.to_thread` (or aiosqlite) | ~1 day | Belt-and-suspenders loop protection | Not started |
 | 6 | Event-loop lag watchdog (task that sleeps 1s, logs when it wakes late) | ~0.5 day | Makes future blocking regressions visible | Partial — the harness ships an offline watchdog; the in-prod one is still to do |
@@ -271,9 +409,14 @@ snapshot) before and after each change.
    holds two small config files, so this was never a memory trade-off. Conclusion: item
    1 delivered as predicted; the remaining `on_message` cost points squarely at items
    4–5 (per-guild settings cache, async DB calls).
-3. Continue down the table in order; re-benchmark after each hot-path change. Items 2
-   and 3 (leak, chunking) don't show up in harness numbers — verify those with the view-
-   store counter (§3) and boot-time/RSS measurements respectively.
+3. ✅ Items 2 (view/modal leak) and 3 (chunking) — done 2026-07-04. As predicted, neither
+   shows up in the harness numbers (they're not on the `on_message` hot path the harness
+   measures). Verify item 2 with the new `-memory` admin command's Active Views/Modals
+   fields (§3) under real load; item 3 still needs a production boot-time/RSS
+   measurement to confirm the "well under a minute" prediction, since nothing in this
+   pass measured that empirically.
+4. Continue down the table in order (items 4–7); re-benchmark after each hot-path
+   change with the harness.
 
 On the radar, not blocking: Postgres only if ever multi-process (SQLite+WAL is fine
 single-process at this scale); consolidate the three overlapping message caches

--- a/src/components/memory_profiler.py
+++ b/src/components/memory_profiler.py
@@ -25,14 +25,19 @@ def _get_nextcord_cache_stats() -> Optional[Dict[str, int]]:
         guilds = bot.guilds
         chunked_guilds = sum(1 for guild in guilds if guild.chunked)
 
-        # all_views() de-duplicates by view id (a view can have multiple
-        # dispatchable items, each with its own entry in the raw store dict).
-        all_views = connection._view_store.all_views()
+        # _view_store._views maps (component_type, message_id, custom_id) -> (view, item),
+        # so a single view with N dispatchable items occupies N entries. Both view metrics
+        # report on this raw-entry scale (rather than the de-duplicated all_views()) so the
+        # duplicated in-memory entries are actually visible and so "active" and "raw_total"
+        # stay comparable (active <= raw_total, the difference being unswept/finished entries).
+        view_entries = connection._view_store._views.values()
+        view_store_active = sum(1 for (view, _item) in view_entries if not view.is_finished())
+        view_store_raw_total = len(connection._view_store._views)
         all_modals = list(connection._modal_store._modals.values())
 
         return {
-            'view_store_active': sum(1 for v in all_views if not v.is_finished()),
-            'view_store_raw_total': len(all_views),
+            'view_store_active': view_store_active,
+            'view_store_raw_total': view_store_raw_total,
             'modal_store_active': sum(1 for m in all_modals if not m.is_finished()),
             'modal_store_raw_total': len(all_modals),
             'chunked_guilds': chunked_guilds,

--- a/src/components/memory_profiler.py
+++ b/src/components/memory_profiler.py
@@ -5,31 +5,88 @@ import logging
 import psutil
 import os
 import threading
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from config.messages import cached_messages
+
+
+def _get_nextcord_cache_stats() -> Optional[Dict[str, int]]:
+    """
+    Get counts of the things nextcord itself is caching in memory.
+
+    :return: Dictionary of nextcord cache stats, or None if the bot isn't
+        connected yet (e.g. before on_ready).
+    :rtype: Optional[Dict[str, int]]
+    """
+    try:
+        from core.bot import get_bot
+        bot = get_bot()
+        connection = bot._connection
+
+        guilds = bot.guilds
+        chunked_guilds = sum(1 for guild in guilds if guild.chunked)
+
+        # all_views() de-duplicates by view id (a view can have multiple
+        # dispatchable items, each with its own entry in the raw store dict).
+        all_views = connection._view_store.all_views()
+        all_modals = list(connection._modal_store._modals.values())
+
+        return {
+            'view_store_active': sum(1 for v in all_views if not v.is_finished()),
+            'view_store_raw_total': len(all_views),
+            'modal_store_active': sum(1 for m in all_modals if not m.is_finished()),
+            'modal_store_raw_total': len(all_modals),
+            'chunked_guilds': chunked_guilds,
+            'total_guilds': len(guilds),
+            # Per-guild Member objects (the ~500k-member concern from section 1).
+            'cached_members_total': sum(len(guild.members) for guild in guilds),
+            # nextcord's global User cache (DM users, message authors, mentions,
+            # etc.) - distinct from per-guild Member objects above.
+            'cached_users_total': len(connection._users),
+            # nextcord's own bounded message cache (max_messages=1000 in
+            # src/core/bot.py) - distinct from InfiniBot's own DB-backed message
+            # cache reported separately below.
+            'nextcord_cached_messages': len(bot.cached_messages),
+        }
+    except Exception:
+        # Bot not ready / not connected yet, or nextcord internals changed.
+        return None
 
 
 def get_memory_stats() -> Dict[str, Any]:
     """
     Get current memory usage statistics.
-    
+
     :return: Dictionary with memory statistics
     :rtype: Dict[str, Any]
     """
     process = psutil.Process(os.getpid())
     memory_info = process.memory_info()
-    
+
     cache_stats = cached_messages.get_cache_stats()
-    
+
     # Count active threads
     active_threads = threading.active_count()
-    
+
+    nextcord_stats = _get_nextcord_cache_stats()
+
+    def _n(key):
+        return nextcord_stats[key] if nextcord_stats else None
+
     return {
         'rss_mb': memory_info.rss / 1024 / 1024,  # Resident Set Size in MB
         'percent': process.memory_percent(),
         'active_threads': active_threads,
         'cached_messages_total': cache_stats['total_messages'],
         'cached_channels': cache_stats['total_channels'],
+        'view_store_active': _n('view_store_active'),
+        'view_store_raw_total': _n('view_store_raw_total'),
+        'modal_store_active': _n('modal_store_active'),
+        'modal_store_raw_total': _n('modal_store_raw_total'),
+        'chunked_guilds': _n('chunked_guilds'),
+        'total_guilds': _n('total_guilds'),
+        'cached_members_total': _n('cached_members_total'),
+        'cached_users_total': _n('cached_users_total'),
+        'nextcord_cached_messages': _n('nextcord_cached_messages'),
     }
 
 
@@ -38,10 +95,15 @@ def log_memory_stats():
     Log current memory statistics.
     """
     stats = get_memory_stats()
-    
+
     log_msg = "Memory: "
     log_msg += f"{stats['rss_mb']:.1f}MB ({stats['percent']:.1f}%), "
     log_msg += f"Threads: {stats['active_threads']}, "
-    log_msg += f"Cached: {stats['cached_messages_total']} msgs / {stats['cached_channels']} channels"
-    
+    log_msg += f"Cached: {stats['cached_messages_total']} msgs / {stats['cached_channels']} channels, "
+    log_msg += f"Views: {stats['view_store_active']} active / {stats['view_store_raw_total']} unswept, "
+    log_msg += f"Modals: {stats['modal_store_active']} active / {stats['modal_store_raw_total']} unswept, "
+    log_msg += f"Chunked: {stats['chunked_guilds']}/{stats['total_guilds']} guilds, "
+    log_msg += f"Members: {stats['cached_members_total']}, Users: {stats['cached_users_total']}, "
+    log_msg += f"nextcord msgs: {stats['nextcord_cached_messages']}"
+
     logging.info(log_msg)

--- a/src/components/ui_components.py
+++ b/src/components/ui_components.py
@@ -1,12 +1,14 @@
 import asyncio
 import copy
 import logging
+from typing import Optional
 
 import nextcord
 from nextcord import Interaction
+from nextcord.utils import MISSING
 
 from components import utils
-from config.global_settings import bot_loaded, get_configs, required_permissions
+from config.global_settings import bot_loaded, get_configs, required_permissions, VIEW_TIMEOUT
 from core.log_manager import get_uuid_for_logging
 
 # View overrides
@@ -165,6 +167,18 @@ class CustomView(nextcord.ui.View):
     :return: None
     :rtype: None
     """
+    def __init__(self,
+        *,
+        timeout: Optional[float] = VIEW_TIMEOUT,
+        auto_defer: bool = True,
+        prevent_update: bool = True):
+        """
+        Initializes the CustomView.
+
+        :param timeout: The timeout for the view. Defaults to None.
+        :type timeout: float | None
+        """
+        super().__init__(timeout=timeout, auto_defer=auto_defer, prevent_update=prevent_update)
     async def on_error(self, error: Exception, item, interaction: Interaction) -> None:
         """
         Handles exceptions raised in the view's item callbacks.
@@ -206,6 +220,21 @@ class CustomModal(nextcord.ui.Modal):
     :return: None
     :rtype: None
     """
+    def __init__(
+        self,
+        title: str,
+        *,
+        timeout: Optional[float] = VIEW_TIMEOUT,
+        custom_id: str = MISSING,
+        auto_defer: bool = True,
+    ) -> None:
+        """
+        Initializes the CustomModal.
+
+        :param title: The title of the modal.
+        :type title: str
+        """
+        super().__init__(title=title, timeout=timeout, custom_id=custom_id, auto_defer=auto_defer)
     async def on_error(self, error: Exception, interaction: Interaction) -> None:
         """
         Handles exceptions raised in the modal's execution.
@@ -346,7 +375,7 @@ class SelectView(CustomView):
         del xindex, yindex
         
         # Add select menu
-        self.select = nextcord.ui.Select(options = [nextcord.SelectOption(label = "PLACEHOLDER!!!")], placeholder=placeholder)
+        self.select = nextcord.ui.Select(custom_id="select_view_select", options = [nextcord.SelectOption(label = "PLACEHOLDER!!!")], placeholder=placeholder)
         self.add_item(self.select)
         
         # Add buttons

--- a/src/components/ui_components.py
+++ b/src/components/ui_components.py
@@ -175,7 +175,7 @@ class CustomView(nextcord.ui.View):
         """
         Initializes the CustomView.
 
-        :param timeout: The timeout for the view. Defaults to None.
+        :param timeout: The timeout for the view. Defaults to VIEW_TIMEOUT. 
         :type timeout: float | None
         """
         super().__init__(timeout=timeout, auto_defer=auto_defer, prevent_update=prevent_update)

--- a/src/components/utils.py
+++ b/src/components/utils.py
@@ -332,7 +332,9 @@ def apply_generic_replacements(
     :rtype: nextcord.Embed
     """
     if not skip_placeholder_replacement:
-        replacements = custom_replacements
+        # Defensive copy: custom_replacements defaults to a shared {} and callers
+        # may reuse their dict, so never mutate the passed-in object in place.
+        replacements = dict(custom_replacements)
 
         if member:
             # Add member-related replacements

--- a/src/components/utils.py
+++ b/src/components/utils.py
@@ -304,10 +304,10 @@ def get_string_from_discord_color(color: nextcord.colour.Colour) -> str | None:
     return None
 
 def apply_generic_replacements(
-    embed: nextcord.Embed, 
-    member: nextcord.Member, 
-    guild: nextcord.Guild, 
-    custom_replacements: dict = {}, 
+    embed: nextcord.Embed,
+    member: nextcord.Member | nextcord.abc.User,
+    guild: nextcord.Guild,
+    custom_replacements: dict = {},
     skip_channel_replacement: bool = False,
     skip_placeholder_replacement: bool = False
 ) -> nextcord.Embed:
@@ -316,8 +316,10 @@ def apply_generic_replacements(
 
     :param embed: The embed to replace placeholders in.
     :type embed: nextcord.Embed
-    :param member: The member to use for placeholder replacement.
-    :type member: nextcord.Member
+    :param member: The member to use for placeholder replacement. May be a plain
+        nextcord.abc.User (e.g. from a raw event, where guild-scoped Member
+        attributes like joined_at aren't available and are guarded below).
+    :type member: nextcord.Member | nextcord.abc.User
     :param guild: The guild to use for placeholder replacement.
     :type guild: nextcord.Guild
     :param custom_replacements: A dictionary of custom placeholder replacements.
@@ -339,7 +341,8 @@ def apply_generic_replacements(
             replacements["@member"] = member.mention
             replacements["@username"] = member.name
             replacements["@id"] = str(member.id)
-            replacements["@joindate"] = member.joined_at.strftime("%Y-%m-%d") if member.joined_at else "Unknown"
+            joined_at = getattr(member, "joined_at", None)
+            replacements["@joindate"] = joined_at.strftime("%Y-%m-%d") if joined_at else "Unknown"
             replacements["@accountage"] = f"{(datetime.datetime.now(datetime.timezone.utc) - member.created_at).days} days" if member.created_at else "Unknown"
         
         if guild:

--- a/src/config/global_settings.py
+++ b/src/config/global_settings.py
@@ -11,6 +11,7 @@ bot_id = None
 
 channels_purging = []
 
+VIEW_TIMEOUT = 60 * 5 # 5 minutes timeout for views
 recently_left_guilds = ExpiringSet(60 * 1) # 1 minute expiration time for guilds that the bot has just left
 
 # Feature dependencies are used to determine if a feature should be enabled or disabled.

--- a/src/core/bot.py
+++ b/src/core/bot.py
@@ -64,7 +64,7 @@ bot = commands.AutoShardedBot(intents = intents,
                             allowed_mentions = nextcord.AllowedMentions(everyone = True), 
                             help_command=None,
                             max_messages=1000,
-                            chunk_guilds_at_startup=True,
+                            chunk_guilds_at_startup=False,
                             guild_ready_timeout=5,  # 5 second timeout for guilds to be ready (default is 2 seconds)
                             shard_count=shard_count)
 
@@ -72,41 +72,6 @@ def get_bot() -> commands.AutoShardedBot: return bot
 
 connected_shards = set()
 post_shards_connected_called = False
-
-async def ensure_guilds_ready(waited=False):
-    """
-    Ensure guilds are properly loaded with retry logic.
-    """
-    unchunked = [guild for guild in bot.guilds if not guild.chunked]
-    if not unchunked:
-        logging.info("✅ All guilds are ready")
-        return
-    
-    if not waited:
-        logging.info(f"⏳ Waiting 15 seconds for guilds to be ready. {len(unchunked)} guilds unchunked.")
-        await asyncio.sleep(15)  # Let auto-chunking finish
-        await ensure_guilds_ready(waited=True)
-        return
-
-    logging.warning(f"Retrying chunking for {len(unchunked)} guilds...")
-
-    for guild in unchunked:
-        try:
-            await asyncio.wait_for(guild.chunk(), timeout=20)
-        except asyncio.TimeoutError:
-            logging.warning(f"⏱️ Guild {guild.name} timed out waiting for chunk; trying REST fallback.")
-            try:
-                # Fallback: Fetch members via REST
-                async for member in guild.fetch_members(limit=None):
-                    pass
-                logging.info(f"✅ Guild {guild.name} fetched via REST fallback.")
-            except Exception as e:
-                logging.warning(f"⚠️ Guild {guild.name} failed REST fallback: {e}")
-        except Exception as e:
-            logging.warning(f"⚠️ Guild {guild.name} failed to chunk: {e}")
-
-    still_unchunked = [g for g in bot.guilds if not g.chunked]
-    logging.info(f"Chunking complete. Remaining unchunked: {len(still_unchunked)}")
 
 @bot.event
 async def on_shard_connect(shard_id: int):
@@ -162,9 +127,6 @@ async def on_ready() -> None: # Bot load
     await bot.wait_until_ready()
     logging.info(f"============================== Logged in as: {bot.user.name} with all shards ready. ==============================")
     logging.info(f"Bot is running with {bot.shard_count} shards across {len(bot.guilds)} guilds.")
-
-    # Start Manual Guild Chunking Sequence
-    await ensure_guilds_ready()
 
     # Initialize core systems
     global_settings.set_bot_load_status(True)
@@ -245,9 +207,7 @@ async def on_shard_ready(shard_id: int) -> None:
 
         # Check if all shards are loaded
         if len(shards_loaded) == bot.shard_count:
-            total_guilds = len(bot.guilds)
-            chunked_guilds = len([g for g in bot.guilds if g.chunked])
-            logging.info(f"All {bot.shard_count} shards loaded. Guilds chunked: {chunked_guilds}/{total_guilds}")
+            logging.info(f"All {bot.shard_count} shards loaded.")
 
 @bot.event
 async def on_close() -> None:
@@ -581,10 +541,7 @@ async def on_raw_message_edit(payload: nextcord.RawMessageUpdateEvent) -> None:
         guild = channel.guild
         if guild is None or not guild.me: 
             return
-        
-        if not guild.chunked:
-            await guild.chunk()
-        
+
         # If we have it, grab the original message
         original_message = payload.cached_message
         if original_message is None:
@@ -600,6 +557,13 @@ async def on_raw_message_edit(payload: nextcord.RawMessageUpdateEvent) -> None:
         with LogIfFailure(feature="cached_messages.remove_cached_message & cached_messages.cache_message"):
             cached_messages.remove_cached_message(edited_message.id, channel.id)
             cached_messages.cache_message(edited_message)
+
+        # Resolve the author if it's not a Member object (e.g., if the member is not cached)
+        if not isinstance(edited_message.author, nextcord.Member):
+            with LogIfFailure(feature="utils.get_member (message edit profanity check)"):
+                resolved_author = await utils.get_member(guild, edited_message.author.id)
+                if resolved_author is not None:
+                    edited_message.author = resolved_author
 
         # Punish profanity (if any)
         with LogIfFailure(feature="moderation.check_and_trigger_profanity_moderation_for_message"):
@@ -648,9 +612,6 @@ async def on_raw_message_delete(payload: nextcord.RawMessageDeleteEvent) -> None
             channel = await utils.get_channel(payload.channel_id, bot=bot)
             if channel is None: 
                 return
-
-            if not guild.chunked:
-                await guild.chunk()
 
             message = payload.cached_message
 
@@ -727,38 +688,41 @@ async def on_member_join(member: nextcord.Member) -> None:
         await default_roles.add_roles_for_new_member(member)
 
 @bot.event
-async def on_member_remove(member: nextcord.Member) -> None:
+async def on_raw_member_remove(payload: nextcord.RawMemberRemoveEvent) -> None:
     """
     Handles member removal events.
 
-    :param member: The member that was removed.
-    :type member: nextcord.Member
+    :param payload: The raw member removal event.
+    :type payload: nextcord.RawMemberRemoveEvent
     :return: None
     :rtype: None
     """
-    if member.id == bot.user.id: return # Don't do anything if WE are removed
-    if member.guild == None: return # Can't do anything if the guild is None
+    guild = payload.guild
+    user = payload.user
+
+    if user.id == bot.user.id: return # Don't do anything if WE are removed
+    if guild is None: return # Can't do anything if the guild is unknown
 
     # Verify that the member was not autobanned
-    if autobans.member_has_autoban(member):
-        logging.info(f"Member {member.id} ({member.name}) was autobanned, skipping leave message and removal handling.")
-        
+    if autobans.member_has_autoban(guild.id, user.id):
+        logging.info(f"Member {user.id} ({user.name}) was autobanned, skipping leave message and removal handling.")
+
         # Log the removal
         with LogIfFailure(feature="action_logging.log_member_removal"):
-            await action_logging.log_member_removal(member.guild, member)
+            await action_logging.log_member_removal(guild, user)
         return
 
     # Trigger the farewell message
     with LogIfFailure(feature="join_leave_messages.trigger_leave_message"):
-        await join_leave_messages.trigger_leave_message(member)
+        await join_leave_messages.trigger_leave_message(guild, user)
 
     # Remove levels
     with LogIfFailure(feature="leveling.handle_member_removal"):
-        await leveling.handle_member_removal(member)
+        await leveling.handle_member_removal(guild.id, user.id)
 
     # Log the removal
     with LogIfFailure(feature="action_logging.log_member_removal"):
-        await action_logging.log_member_removal(member.guild, member)
+        await action_logging.log_member_removal(guild, user)
 
 @bot.event
 async def on_guild_join(guild: nextcord.Guild) -> None:

--- a/src/features/action_logging.py
+++ b/src/features/action_logging.py
@@ -889,7 +889,7 @@ async def log_member_update(before: nextcord.Member, after: nextcord.Member) -> 
     if before.communication_disabled_until != after.communication_disabled_until:
         await log_timeout_change(before, after, entry, log_channel)
 
-async def log_member_removal(guild: nextcord.Guild, member: nextcord.Member) -> None:
+async def log_member_removal(guild: nextcord.Guild, member: nextcord.abc.User) -> None:
     """
     |coro|
 
@@ -898,7 +898,7 @@ async def log_member_removal(guild: nextcord.Guild, member: nextcord.Member) -> 
     :param guild: The guild the member was removed from.
     :type guild: nextcord.Guild
     :param member: The member that was removed.
-    :type member: nextcord.Member
+    :type member: nextcord.abc.User
     :return: None
     :rtype: None
     """
@@ -908,9 +908,6 @@ async def log_member_removal(guild: nextcord.Guild, member: nextcord.Member) -> 
     log_channel = await get_logging_channel(guild)
     if not log_channel: return # Logging is not enabled for this guild
 
-    if not guild.chunked:
-        await guild.chunk()
-        
     if guild.me == None: return
     
     try:

--- a/src/features/admin_commands.py
+++ b/src/features/admin_commands.py
@@ -608,13 +608,28 @@ async def handle_memory_command(message: nextcord.Message):
     
     try:
         stats = get_memory_stats()
-        
-        # Format statistics
+
+        # Format statistics (nextcord-side stats may be None if the bot isn't
+        # fully connected yet)
+        def _fmt(key):
+            value = stats[key]
+            return value if value is not None else 'N/A'
+
+        chunked_guilds = _fmt('chunked_guilds')
+        total_guilds = _fmt('total_guilds')
         description = (
             f"**Memory:** {stats['rss_mb']:.1f} MB ({stats['percent']:.1f}%)\n"
             f"**Threads:** {stats['active_threads']}\n"
-            f"**Cached Messages:** {stats['cached_messages_total']}\n"
-            f"**Cached Channels:** {stats['cached_channels']}"
+            f"**Cached Messages (DB):** {stats['cached_messages_total']}\n"
+            f"**Cached Channels:** {stats['cached_channels']}\n"
+            f"**Active Views:** {_fmt('view_store_active')} "
+            f"(*{_fmt('view_store_raw_total')} unswept in store*)\n"
+            f"**Active Modals:** {_fmt('modal_store_active')} "
+            f"(*{_fmt('modal_store_raw_total')} unswept in store*)\n"
+            f"**Chunked Guilds:** {chunked_guilds}/{total_guilds}\n"
+            f"**Cached Members:** {_fmt('cached_members_total')}\n"
+            f"**Cached Users:** {_fmt('cached_users_total')}\n"
+            f"**Cached Messages (nextcord):** {_fmt('nextcord_cached_messages')}"
         )
         
         # Determine color based on memory usage
@@ -796,7 +811,7 @@ async def handle_send_message_to_all_servers_command(message: nextcord.Message):
 
     class EmbedCreationView(CustomView):
         def __init__(self, author: nextcord.User):
-            super().__init__(timeout=None)
+            super().__init__()
             self.author = author
             self.embed_data = {}
         

--- a/src/features/autobans.py
+++ b/src/features/autobans.py
@@ -15,7 +15,7 @@ async def check_and_run_autoban_for_member(member: nextcord.Member) -> bool:
         bool: True if the member was autobanned, False otherwise.
     """
     
-    if member_has_autoban(member):
+    if member_has_autoban(member.guild.id, member.id):
         # The member is autobanned. Ban them.
         
         # However, wait a moment to ensure that things settle out
@@ -41,14 +41,15 @@ async def check_and_run_autoban_for_member(member: nextcord.Member) -> bool:
 
     return False
 
-def member_has_autoban(member: nextcord.Member) -> bool:
+def member_has_autoban(guild_id: int, member_id: int) -> bool:
     """
     Checks if a member has an autoban entry.
 
     Args:
-        member (nextcord.Member): The member to check.
+        guild_id (int): The ID of the guild to check.
+        member_id (int): The ID of the member to check.
     Returns:
         bool: True if the member has an autoban entry, False otherwise.
     """
-    server = Server(member.guild.id)
-    return len(server.autobans.get_matching(member_id=member.id)) > 0
+    server = Server(guild_id)
+    return len(server.autobans.get_matching(member_id=member_id)) > 0

--- a/src/features/dashboard.py
+++ b/src/features/dashboard.py
@@ -26,7 +26,7 @@ class Dashboard(CustomView):
     This is the main view for the dashboard feature.
     """
     def __init__(self, guild_id):
-        super().__init__(timeout = None)
+        super().__init__()
         
         self.moderation_btn = self.ModerationButton(self)
         self.add_item(self.moderation_btn)
@@ -109,7 +109,7 @@ class Dashboard(CustomView):
           
         class ModerationView(CustomView):
             def __init__(self, outer):
-                super().__init__(timeout = None)
+                super().__init__()
                 self.outer = outer
                 
                 self.profane_moderation_btn = self.ProfaneModerationButton(self)
@@ -156,7 +156,7 @@ class Dashboard(CustomView):
                     
                 class ProfaneModerationView(CustomView):
                     def __init__(self, outer, guild_id, onboarding_modifier = None, onboarding_embed = None):
-                        super().__init__(timeout = None)
+                        super().__init__()
                         self.outer = outer
                         self.onboarding_modifier = onboarding_modifier
                         self.onboarding_embed = onboarding_embed
@@ -251,7 +251,7 @@ class Dashboard(CustomView):
                             
                         class FilteredWordsView(CustomView): #Filtered Words Window -----------------------------------------------------
                             def __init__(self, outer):
-                                super().__init__(timeout = None)
+                                super().__init__()
                                 self.outer = outer
                                 
                                 self.add_word_btn = self.AddWordButton(self)
@@ -520,7 +520,7 @@ class Dashboard(CustomView):
                                     
                                 class ResetConfirmationView(CustomView):
                                     def __init__(self, outer):
-                                        super().__init__(timeout = None)
+                                        super().__init__()
                                         self.outer = outer
                                         
                                         self.back_btn = nextcord.ui.Button(label = "Back", style = nextcord.ButtonStyle.secondary)
@@ -673,7 +673,7 @@ class Dashboard(CustomView):
                             
                         class ManageStrikeSystemView(CustomView):
                             def __init__(self, outer, guild_id:int):
-                                super().__init__(timeout = None)
+                                super().__init__()
                                 self.outer = outer
 
                                 server = Server(guild_id)
@@ -755,7 +755,7 @@ class Dashboard(CustomView):
                                     
                                 class ManageMembersView(CustomView):
                                     def __init__(self, outer):
-                                        super().__init__(timeout=None)
+                                        super().__init__()
                                         self.outer = outer
 
                                         self.add_item(self.EditStrikesButton(self))
@@ -823,7 +823,7 @@ class Dashboard(CustomView):
                                         
                                         class MemberSelectView(CustomView):
                                             def __init__(self, outer):
-                                                super().__init__(timeout=None)
+                                                super().__init__()
                                                 self.outer = outer
                                                 
                                                 self.member_select = nextcord.ui.UserSelect(
@@ -857,7 +857,7 @@ class Dashboard(CustomView):
 
                                             class EditStrikesView(CustomView):
                                                 def __init__(self, outer, guild: nextcord.Guild, user_selection: nextcord.User):
-                                                    super().__init__(timeout=None)
+                                                    super().__init__()
                                                     self.outer = outer
 
                                                     self.member_name = user_selection.display_name
@@ -871,7 +871,7 @@ class Dashboard(CustomView):
                                                         for level in range(server.profanity_moderation_profile.max_strikes + 1)
                                                     ][::-1] # invert list
                                                     
-                                                    self.strike_select = nextcord.ui.Select(options=strike_levels, placeholder="Choose a Strike Level")
+                                                    self.strike_select = nextcord.ui.Select(custom_id="strike_level_select", options=strike_levels, placeholder="Choose a Strike Level")
                                                     self.strike_select.callback = self.confirm_selection
                                                     self.add_item(self.strike_select)
                                                     
@@ -913,7 +913,7 @@ class Dashboard(CustomView):
 
                                         class ResetAllStrikesView(CustomView):
                                             def __init__(self, outer):
-                                                super().__init__(timeout=None)
+                                                super().__init__()
                                                 self.outer = outer
                                                 
                                                 no_btn = nextcord.ui.Button(label="No", style=nextcord.ButtonStyle.danger)
@@ -1023,7 +1023,7 @@ class Dashboard(CustomView):
                                     
                                 class EnableDisableView(CustomView):
                                     def __init__(self, outer):
-                                        super().__init__(timeout = None)
+                                        super().__init__()
                                         self.outer = outer
                                         
                                         self.back_btn = nextcord.ui.Button(label = "Cancel", style = nextcord.ButtonStyle.danger)
@@ -1077,7 +1077,7 @@ class Dashboard(CustomView):
                                     
                                 class EnableDisableView(CustomView):
                                     def __init__(self, outer):
-                                        super().__init__(timeout = None)
+                                        super().__init__()
                                         self.outer = outer
                                         
                                         self.back_btn = nextcord.ui.Button(label = "Cancel", style = nextcord.ButtonStyle.danger)
@@ -1142,7 +1142,7 @@ class Dashboard(CustomView):
                             
                         class EnableDisableView(CustomView):
                             def __init__(self, outer):
-                                super().__init__(timeout = None)
+                                super().__init__()
                                 self.outer = outer
                                 
                                 self.back_btn = nextcord.ui.Button(label = "Cancel", style = nextcord.ButtonStyle.danger)
@@ -1207,7 +1207,7 @@ class Dashboard(CustomView):
                     
                 class SpamModerationView(CustomView):
                     def __init__(self, outer, onboarding_modifier = None, onboarding_embed = None):
-                        super().__init__(timeout = None)
+                        super().__init__()
                         self.outer = outer
                         self.onboarding_modifier = onboarding_modifier
                         self.onboarding_embed = onboarding_embed
@@ -1389,7 +1389,7 @@ class Dashboard(CustomView):
                             
                         class EnableDisableView(CustomView):
                             def __init__(self, outer):
-                                super().__init__(timeout = None)
+                                super().__init__()
                                 self.outer = outer
                                 
                                 self.back_btn = nextcord.ui.Button(label = "Cancel", style = nextcord.ButtonStyle.danger)
@@ -1449,7 +1449,7 @@ class Dashboard(CustomView):
                             
                         class EnableDisableView(CustomView):
                             def __init__(self, outer):
-                                super().__init__(timeout = None)
+                                super().__init__()
                                 self.outer = outer
                                 
                                 self.back_btn = nextcord.ui.Button(label = "Cancel", style = nextcord.ButtonStyle.danger)
@@ -1514,7 +1514,7 @@ class Dashboard(CustomView):
 
                 class AdminRolesView(CustomView):
                     def __init__(self, outer):
-                        super().__init__(timeout = None)
+                        super().__init__()
                         self.outer = outer
                         
                         self.add_role_btn = self.AddRoleButton(self)
@@ -1660,7 +1660,7 @@ class Dashboard(CustomView):
                             
                         class DeleteAllAdminRolesView(CustomView):
                             def __init__(self, outer):
-                                super().__init__(timeout = None)
+                                super().__init__()
                                 self.outer = outer
                                 
                                 self.no_btn = nextcord.ui.Button(label = "No", style = nextcord.ButtonStyle.danger)
@@ -1701,7 +1701,7 @@ class Dashboard(CustomView):
             
         class LoggingView(CustomView): #Logging Window -----------------------------------------------------
             def __init__(self, outer, onboarding_modifier = None, onboarding_embed = None):
-                super().__init__(timeout = None)
+                super().__init__()
                 self.outer = outer
                 self.onboarding_modifier = onboarding_modifier
                 self.onboarding_embed = onboarding_embed
@@ -1842,7 +1842,7 @@ class Dashboard(CustomView):
                     
                 class EnableDisableView(CustomView):
                     def __init__(self, outer):
-                        super().__init__(timeout = None)
+                        super().__init__()
                         self.outer = outer
                         
                         self.back_btn = nextcord.ui.Button(label = "Cancel", style = nextcord.ButtonStyle.danger)
@@ -1906,7 +1906,7 @@ class Dashboard(CustomView):
             
         class LevelingView(CustomView):
             def __init__(self, outer, onboarding_modifier = None, onboarding_embed = None):
-                super().__init__(timeout = None)
+                super().__init__()
                 self.outer = outer
                 self.onboarding_modifier = onboarding_modifier
                 self.onboarding_embed = onboarding_embed
@@ -1997,7 +1997,7 @@ class Dashboard(CustomView):
                     
                 class MembersView(CustomView):#Members View Window -----------------------------------------------------
                     def __init__(self, outer):
-                        super().__init__(timeout=None)
+                        super().__init__()
                         self.outer = outer
                         
                         self.edit_level_btn = self.EditLevelButton(self)
@@ -2027,7 +2027,7 @@ class Dashboard(CustomView):
                                                                                
                         class MemberSelectView(CustomView):
                             def __init__(self, outer):
-                                super().__init__(timeout=None)
+                                super().__init__()
                                 self.outer = outer
                                 
                                 self.member_select = nextcord.ui.UserSelect(
@@ -2121,7 +2121,7 @@ class Dashboard(CustomView):
                             
                         class DeleteAllLevelsView(CustomView):
                             def __init__(self, outer):
-                                super().__init__(timeout = None)
+                                super().__init__()
                                 self.outer = outer
                                 
                                 self.no_btn = nextcord.ui.Button(label = "No", style = nextcord.ButtonStyle.danger)
@@ -2159,7 +2159,7 @@ class Dashboard(CustomView):
                     
                 class LevelRewardsView(CustomView): # Level Rewards Window -----------------------------------------------------
                     def __init__(self, outer):
-                        super().__init__(timeout = None)
+                        super().__init__()
                         self.outer = outer
                         
                         self.create_level_reward_btn = self.CreateLevelRewardButton(self)
@@ -2333,7 +2333,7 @@ class Dashboard(CustomView):
                             
                         class DeleteAllLevelsView(CustomView):
                             def __init__(self, outer):
-                                super().__init__(timeout = None)
+                                super().__init__()
                                 self.outer = outer
                                 
                                 self.no_btn = nextcord.ui.Button(label = "No", style = nextcord.ButtonStyle.danger)
@@ -2416,7 +2416,7 @@ class Dashboard(CustomView):
                     
                 class LevelingMessageModal(CustomModal): #Leveling Message Modal -----------------------------------------------------
                     def __init__(self, guild: nextcord.Guild, outer):
-                        super().__init__(timeout = None, title = "Level-Up Message")
+                        super().__init__(title = "Level-Up Message")
                         self.outer = outer
                         
                         server = Server(guild.id)
@@ -2451,7 +2451,7 @@ class Dashboard(CustomView):
 
                 class AdvancedView(CustomView):
                     def __init__(self, outer):
-                        super().__init__(timeout = None)
+                        super().__init__()
                         self.outer = outer
 
                         self.points_lost_per_day_btn = self.PointsLostPerDayButton(self)
@@ -2505,7 +2505,7 @@ class Dashboard(CustomView):
                             
                         class PointsLostPerDayModal(CustomModal): #Leveling Message Modal -----------------------------------------------------
                             def __init__(self, guild: nextcord.Guild, outer):
-                                super().__init__(timeout = None, title = "Points Lost Per Day")
+                                super().__init__(title = "Points Lost Per Day")
                                 self.outer = outer
                                 
                                 server = Server(guild.id)
@@ -2544,7 +2544,7 @@ class Dashboard(CustomView):
                             
                         class MaxPointsPerMessageModal(CustomModal): #Leveling Message Modal -----------------------------------------------------
                             def __init__(self, guild: nextcord.Guild, outer):
-                                super().__init__(timeout = None, title = "Max Points Per Message")
+                                super().__init__(title = "Max Points Per Message")
                                 self.outer = outer
                                 
                                 server = Server(guild.id)
@@ -2583,7 +2583,7 @@ class Dashboard(CustomView):
                             
                         class LevelCardsView(CustomView):
                             def __init__(self, outer, interaction: Interaction):
-                                super().__init__(timeout = None)
+                                super().__init__()
                                 self.outer = outer
                                 
                                 server = Server(interaction.guild.id)
@@ -2628,7 +2628,7 @@ class Dashboard(CustomView):
                             
                         class ExemptChannelsView(CustomView):
                             def __init__(self, outer, interaction: Interaction):
-                                super().__init__(timeout = None)
+                                super().__init__()
                                 self.outer = outer 
                                 
                                 add_button = self.AddButton(self, interaction)
@@ -2768,7 +2768,7 @@ class Dashboard(CustomView):
                     
                 class EnableDisableView(CustomView):
                     def __init__(self, outer):
-                        super().__init__(timeout = None)
+                        super().__init__()
                         self.outer = outer
                         
                         self.back_btn = nextcord.ui.Button(label = "Cancel", style = nextcord.ButtonStyle.danger)
@@ -2833,7 +2833,7 @@ class Dashboard(CustomView):
             
         class JoinLeaveMessagesView(CustomView):
             def __init__(self, outer, onboarding_modifier = None, onboarding_embed = None):
-                super().__init__(timeout = None)
+                super().__init__()
                 self.outer = outer
                 self.onboarding_modifier = onboarding_modifier
                 self.onboarding_embed = onboarding_embed
@@ -2882,7 +2882,7 @@ class Dashboard(CustomView):
 
                 class JoinMessagesView(CustomView): #Join Messages Window --------------------------------------------
                     def __init__(self, outer):
-                        super().__init__(timeout = None)
+                        super().__init__()
                         self.outer = outer
                         
                         self.join_message_btn = self.JoinMessageButton(self)
@@ -2950,7 +2950,7 @@ class Dashboard(CustomView):
                             
                         class JoinMessageModal(CustomModal): #Join Message Modal -----------------------------------------------------
                             def __init__(self, guild: nextcord.Guild, outer):
-                                super().__init__(timeout = None, title = "Join Message")
+                                super().__init__(title = "Join Message")
                                 self.outer = outer
                                 
                                 server = Server(guild.id)
@@ -3025,7 +3025,7 @@ class Dashboard(CustomView):
                             
                         class CardsView(CustomView): # Join Cards
                             def __init__(self, outer, interaction: Interaction):
-                                super().__init__(timeout = None)
+                                super().__init__()
                                 self.outer = outer
                                 
                                 server = Server(interaction.guild.id)
@@ -3078,7 +3078,7 @@ class Dashboard(CustomView):
                             
                         class EnableDisableView(CustomView):
                             def __init__(self, outer):
-                                super().__init__(timeout = None)
+                                super().__init__()
                                 self.outer = outer
                                 
                                 self.back_btn = nextcord.ui.Button(label = "Cancel", style = nextcord.ButtonStyle.danger)
@@ -3145,7 +3145,7 @@ class Dashboard(CustomView):
 
                 class LeaveMessagesView(CustomView): #Leave Messages Window --------------------------------------------
                     def __init__(self, outer):
-                        super().__init__(timeout = None)
+                        super().__init__()
                         self.outer = outer
                         
                         self.leave_message_btn = self.LeaveMessagesButton(self)
@@ -3206,7 +3206,7 @@ class Dashboard(CustomView):
                             
                         class LeaveMessagesModal(CustomModal): #Leave Message Modal -----------------------------------------------------
                             def __init__(self, guild: nextcord.Guild, outer):
-                                super().__init__(timeout = None, title = "Leave Message")
+                                super().__init__(title = "Leave Message")
                                 self.outer = outer
                                 
                                 server = Server(guild.id)
@@ -3281,7 +3281,7 @@ class Dashboard(CustomView):
                             
                         class EnableDisableView(CustomView):
                             def __init__(self, outer):
-                                super().__init__(timeout = None)
+                                super().__init__()
                                 self.outer = outer
                                 
                                 self.back_btn = nextcord.ui.Button(label = "Cancel", style = nextcord.ButtonStyle.danger)
@@ -3354,7 +3354,7 @@ class Dashboard(CustomView):
                 
         class BirthdaysView(CustomView):
             def __init__(self, outer, onboarding_modifier=None, onboarding_embed=None):
-                super().__init__(timeout=None)
+                super().__init__()
                 self.outer = outer
                 self.onboarding_modifier = onboarding_modifier
                 self.onboarding_embed = onboarding_embed
@@ -3412,7 +3412,7 @@ class Dashboard(CustomView):
                     )
                     configure_btn.callback = lambda i: self.outer.configure_timezone_btn.callback(i)
                     
-                    view = CustomView(timeout=None)
+                    view = CustomView()
                     view.add_item(back_btn)
                     view.add_item(configure_btn)
                     await interaction.response.edit_message(embed=embed, view=view)
@@ -3476,7 +3476,7 @@ class Dashboard(CustomView):
 
                 class ConfigureBirthdaysView(CustomView):
                     def __init__(self, outer):
-                        super().__init__(timeout=None)
+                        super().__init__()
                         self.outer = outer
 
                         self.add_birthday_btn = self.AddBirthdayButton(self)
@@ -3546,7 +3546,7 @@ class Dashboard(CustomView):
                             
                         class MemberSelectView(CustomView):
                             def __init__(self, outer):
-                                super().__init__(timeout=None)
+                                super().__init__()
                                 self.outer = outer
                                 
                                 self.member_select = nextcord.ui.UserSelect(
@@ -3598,7 +3598,7 @@ class Dashboard(CustomView):
                             
                             class InfoModal(CustomModal):            
                                 def __init__(self, outer, member_id):
-                                    super().__init__(title="Add Birthday", timeout=None)
+                                    super().__init__(title="Add Birthday")
                                     self.outer = outer
                                     self.member_id = member_id
                                     
@@ -3687,7 +3687,7 @@ class Dashboard(CustomView):
                                             
                         class InfoModal(CustomModal):            
                             def __init__(self, outer, member_id, guild_id):
-                                super().__init__(title="Edit Birthday", timeout=None)
+                                super().__init__(title="Edit Birthday")
                                 self.outer = outer
                                 self.member_id = member_id
                                 
@@ -3784,7 +3784,7 @@ class Dashboard(CustomView):
                                 
                         class DeleteAllStrikesView(CustomView):
                             def __init__(self, outer):
-                                super().__init__(timeout=None)
+                                super().__init__()
                                 self.outer = outer
                                 
                                 self.no_btn = nextcord.ui.Button(label="No", style=nextcord.ButtonStyle.danger)
@@ -3887,7 +3887,7 @@ class Dashboard(CustomView):
 
                 class SetMessageTimeModal(CustomModal):
                     def __init__(self, outer, guild_id):
-                        super().__init__(title="Set Message Time", timeout=None)
+                        super().__init__(title="Set Message Time")
                         self.outer = outer
                         self.guild_id = guild_id
                         
@@ -3992,7 +3992,7 @@ class Dashboard(CustomView):
                         )
                         configure_btn.callback = lambda i: self.outer.outer.configure_timezone_btn.callback(i)
                         
-                        view = CustomView(timeout=None)
+                        view = CustomView()
                         view.add_item(configure_btn)
                         await interaction.response.edit_message(embed=embed, view=view)
                         return
@@ -4006,7 +4006,7 @@ class Dashboard(CustomView):
                     
                 class EditMessageModal(CustomModal):
                     def __init__(self, guild: nextcord.Guild, outer):
-                        super().__init__(title="Birthday Message", timeout=None)
+                        super().__init__(title="Birthday Message")
                         self.outer = outer
                         
                         server = Server(guild.id)
@@ -4056,7 +4056,7 @@ class Dashboard(CustomView):
             
         class DefaultRolesView(CustomView):
             def __init__(self, outer, onboarding_modifier=None, onboarding_embed=None):
-                super().__init__(timeout = None)
+                super().__init__()
                 self.outer = outer
                 self.onboarding_modifier = onboarding_modifier
                 self.onboarding_embed = onboarding_embed
@@ -4213,7 +4213,7 @@ class Dashboard(CustomView):
                     
                 class DeleteAllDefaultRolesView(CustomView):
                     def __init__(self, outer):
-                        super().__init__(timeout = None)
+                        super().__init__()
                         self.outer = outer
                         
                         self.no_btn = nextcord.ui.Button(label = "No", style = nextcord.ButtonStyle.danger)
@@ -4250,7 +4250,7 @@ class Dashboard(CustomView):
                     
         class JoinToCreateVCsView(CustomView):
             def __init__(self, outer, guild: nextcord.Guild, onboarding_modifier = None, onboarding_embed = None):
-                super().__init__(timeout=None)
+                super().__init__()
                 self.outer = outer
                 self.guild = guild
                 self.onboarding_modifier = onboarding_modifier
@@ -4493,7 +4493,7 @@ class Dashboard(CustomView):
             
         class AutoBansView(nextcord.ui.View):
             def __init__(self, outer):
-                super().__init__(timeout=None)
+                super().__init__()
                 self.outer = outer
                 
                 # Create buttons
@@ -4569,7 +4569,7 @@ class Dashboard(CustomView):
                                                 
                 class IDHelp(nextcord.ui.View):
                     def __init__(self, outer):
-                        super().__init__(timeout=None)
+                        super().__init__()
                         self.outer = outer
                         
                         self.back_btn = nextcord.ui.Button(label="Back", style=nextcord.ButtonStyle.danger)
@@ -4614,7 +4614,7 @@ class Dashboard(CustomView):
                         
                     class AddModal(nextcord.ui.Modal):
                         def __init__(self, outer):
-                            super().__init__(title="Add AutoBan", timeout=None)
+                            super().__init__(title="Add AutoBan")
                             self.outer = outer
                             self.user_name = None
                             self.id = None
@@ -4758,7 +4758,7 @@ class Dashboard(CustomView):
             
         class ExtraFeaturesButton(CustomView):
             def __init__(self, outer):
-                super().__init__(timeout = None)
+                super().__init__()
                 self.outer = outer
 
                 items = {
@@ -4808,7 +4808,7 @@ class Dashboard(CustomView):
                     
                 class ChooseView(CustomView):
                     def __init__(self, outer, name, guild_id, path):
-                        super().__init__(timeout = None)
+                        super().__init__()
                         self.outer = outer
                         self.name = name
                         self.guild_id = guild_id
@@ -4877,7 +4877,7 @@ class Dashboard(CustomView):
 
         class ConfigureTimezoneView(CustomView):
             def __init__(self, outer, onboarding_modifier=None, onboarding_embed=None):
-                super().__init__(timeout = None)
+                super().__init__()
                 self.outer = outer
                 self.onboarding_modifier = onboarding_modifier
                 self.onboarding_embed = onboarding_embed

--- a/src/features/embeds.py
+++ b/src/features/embeds.py
@@ -68,7 +68,7 @@ class EmbedColorView(CustomView):
         for option in utils.COLOR_OPTIONS:
             select_options.append(nextcord.SelectOption(label=option, value=option))
         
-        self.select = nextcord.ui.Select(placeholder="Choose a color", options=select_options)
+        self.select = nextcord.ui.Select(custom_id="embed_color_select", placeholder="Choose a color", options=select_options)
 
         self.button = nextcord.ui.Button(label="Create", style=nextcord.ButtonStyle.blurple)
         self.button.callback = self.create_callback

--- a/src/features/join_leave_messages.py
+++ b/src/features/join_leave_messages.py
@@ -62,30 +62,32 @@ async def trigger_join_message(member: nextcord.Member) -> None:
         
         await channel.send(embeds = embeds)
             
-async def trigger_leave_message(member: nextcord.Member) -> None:
+async def trigger_leave_message(guild: nextcord.Guild, member: nextcord.abc.User) -> None:
     """
     |coro|
 
     Trigger the leave message functionality.
-    
-    :param member: The member that has left. This is a required parameter.
-    :type member: nextcord.Member
+
+    :param guild: The guild the member left. This is a required parameter.
+    :type guild: nextcord.Guild
+    :param member: The member that has left.
+    :type member: nextcord.abc.User
     :return: None
     :rtype: None
     """
     if member == None: return
-    if member.guild == None: return
-    if member.guild.id == None: return
-    
-    server = Server(member.guild.id)
-            
+    if guild == None: return
+    if guild.id == None: return
+
+    server = Server(guild.id)
+
     if utils.feature_is_active(server = server, feature = "leave_messages"): # Check if leave messages are enabled
         if server.leave_message_profile.channel != UNSET_VALUE: # Find join channel
             channel_id = server.leave_message_profile.channel
             channel = await utils.get_channel(channel_id)
             if channel == None:
                 await utils.send_error_message_to_server_owner(
-                    member.guild,
+                    guild,
                     None,
                     message=(
                         f"InfiniBot is unable to find your leave message channel. "
@@ -95,18 +97,18 @@ async def trigger_leave_message(member: nextcord.Member) -> None:
                 )
                 return
         else:
-            if member.guild.system_channel != None:
-                channel = member.guild.system_channel
+            if guild.system_channel != None:
+                channel = guild.system_channel
             else:
                 return
-        
+
         # Double check permissions
         if channel and not await utils.check_text_channel_permissions(channel, True, custom_channel_name = f"Leave Message Channel (#{channel.name})"):
             return
-            
+
         # Send message
         leave_message_embed: nextcord.Embed = server.leave_message_profile.embed.to_embed()
-        leave_message_embed = utils.apply_generic_replacements(leave_message_embed, member, member.guild)
+        leave_message_embed = utils.apply_generic_replacements(leave_message_embed, member, guild)
         leave_message_embed.timestamp = datetime.datetime.now()
-        
+
         await channel.send(embed = leave_message_embed)

--- a/src/features/jokes.py
+++ b/src/features/jokes.py
@@ -298,7 +298,7 @@ async def _get_member_in_support_server(member_id: int):
 
 class JokeView(CustomView):
     def __init__(self):
-        super().__init__(timeout=3600) # 1 hour timeout
+        super().__init__(timeout=None)
 
         if utils.feature_is_active(feature="joke_submissions"):
             self.button = nextcord.ui.Button(

--- a/src/features/jokes.py
+++ b/src/features/jokes.py
@@ -298,7 +298,7 @@ async def _get_member_in_support_server(member_id: int):
 
 class JokeView(CustomView):
     def __init__(self):
-        super().__init__(timeout=None)
+        super().__init__(timeout=3600) # 1 hour timeout
 
         if utils.feature_is_active(feature="joke_submissions"):
             self.button = nextcord.ui.Button(
@@ -310,7 +310,7 @@ class JokeView(CustomView):
 
     class SubmitJokeModal(CustomModal):
         def __init__(self):
-            super().__init__(title="Submit a Joke", timeout=None)
+            super().__init__(title="Submit a Joke")
 
             self.joke_title = nextcord.ui.TextInput(
                 label="Title",
@@ -409,7 +409,7 @@ class JokeVerificationView(CustomView):
     async def deny(self, button: nextcord.ui.Button, interaction: Interaction):
         class Modal(CustomModal):
             def __init__(self, message: nextcord.Message, member: nextcord.Member):
-                super().__init__(title="Reason to Deny", timeout=None)
+                super().__init__(title="Reason to Deny")
                 self.message = message
                 self.member = member
 
@@ -426,7 +426,7 @@ class JokeVerificationView(CustomView):
 
                 class ConfirmView(CustomView):
                     def __init__(self, message: nextcord.Message, reason: str, member: nextcord.Member | None):
-                        super().__init__(timeout=None)
+                        super().__init__()
                         self.message = message
                         self.reason = reason
                         self.member = member
@@ -522,7 +522,7 @@ class JokeVerificationView(CustomView):
     async def verify(self, button: nextcord.ui.Button, interaction: Interaction):
         class Modal(CustomModal):
             def __init__(self, message: nextcord.Message):
-                super().__init__(title="Finalize Joke", timeout=None)
+                super().__init__(title="Finalize Joke")
                 self.message = message
 
                 joke, extracted_info = _extract_info_from_joke_submission_embed(message.embeds[0])
@@ -570,7 +570,7 @@ class JokeVerificationView(CustomView):
                         member_id: int,
                         member: nextcord.Member | None
                     ):
-                        super().__init__(timeout=None)
+                        super().__init__()
                         self.message = message
                         self.joke_title = joke_title
                         self.joke_body = joke_body

--- a/src/features/leveling.py
+++ b/src/features/leveling.py
@@ -483,19 +483,21 @@ async def process_level_change(guild: nextcord.Guild, member: nextcord.Member, l
                                 # DMs are disabled
                                 pass
 
-async def handle_member_removal(member: nextcord.Member):
+async def handle_member_removal(guild_id: int, member_id: int):
     """
     Handles the removal of a member from the server.
 
-    :param member: The member object that was removed from the server.
-    :type member: nextcord.Member
+    :param guild_id: The ID of the guild the member was removed from.
+    :type guild_id: int
+    :param member_id: The ID of the member that was removed from the server.
+    :type member_id: int
     :return: None
     :rtype: None
     """
-    server = Server(member.guild.id)
+    server = Server(guild_id)
     if utils.feature_is_active(server = server, feature = "leveling"):
-        if member.id in server.member_levels:
-            server.member_levels.delete(member.id)
+        if member_id in server.member_levels:
+            server.member_levels.delete(member_id)
 
 # Commands
 async def run_leaderboard_command(interaction: Interaction):

--- a/src/features/moderation.py
+++ b/src/features/moderation.py
@@ -150,9 +150,12 @@ async def check_and_punish_nickname_for_profanity(bot: nextcord.Client, guild: n
     server = Server(guild.id)
     if not utils.feature_is_active(server = server, feature = "moderation__profanity"): return
 
-    if not guild.chunked:
-        await guild.chunk()
-    
+    # Note: with chunk_guilds_at_startup disabled, on_member_update is only ever
+    # dispatched for members nextcord has already cached (join, voice state, or a
+    # prior update), so `member`/`after` here are always fully populated. The very
+    # first nickname change for a not-yet-cached member is silently missed by
+    # nextcord itself before this handler is even invoked - an accepted limitation
+    # (see documentation/scale_performance_assessment_2026-07.md section 1).
     if nickname == None: return
     if member.guild_permissions.administrator: return
 
@@ -222,7 +225,7 @@ async def check_and_punish_nickname_for_profanity(bot: nextcord.Client, guild: n
 
             {f"{member.mention} was timed out for {timeout_time}" if strikes == 0 else f"{member.mention} is now at strike {strikes} / {server.profanity_moderation_profile.max_strikes}"}
 
-            {"InfiniBot automatically reverted their nickname to their original name." if nickname_removed else "InfiniBot could not revert their nickname due to lack of permissions."}
+            {"InfiniBot automatically reverted their nickname to their base name." if nickname_removed else "InfiniBot could not revert their nickname due to lack of permissions."}
             """
             description = utils.standardize_str_indention(description)
             embed =  nextcord.Embed(title = "Profanity Detected", description = description, color = nextcord.Color.dark_red())

--- a/src/features/onboarding.py
+++ b/src/features/onboarding.py
@@ -10,7 +10,7 @@ from features.dashboard import Dashboard
 
 class Onboarding(CustomView):
     def __init__(self):
-        super().__init__(timeout=None)
+        super().__init__()
         
         self.dropdown_options = [
             ["Profanity Moderation", "Automatically moderate your server for profanity."],
@@ -25,9 +25,10 @@ class Onboarding(CustomView):
         
         formatted_options = [nextcord.SelectOption(label=option[0], description=option[1]) for option in self.dropdown_options]
         self.dropdown = nextcord.ui.Select(
-            placeholder="Select Features", 
-            min_values=0, 
-            max_values=len(formatted_options), 
+            custom_id="onboarding_feature_select",
+            placeholder="Select Features",
+            min_values=0,
+            max_values=len(formatted_options),
             options=formatted_options
         )
         self.add_item(self.dropdown)
@@ -70,7 +71,7 @@ class Onboarding(CustomView):
             
         class CancelView(CustomView):
             def __init__(self, outer):
-                super().__init__(timeout=None)
+                super().__init__()
                 self.outer = outer
                 
                 self.go_back_btn = nextcord.ui.Button(label="Go Back")
@@ -101,7 +102,7 @@ class Onboarding(CustomView):
             
         class OnboardingInfoView(CustomView):
             def __init__(self, outer, order: list):
-                super().__init__(timeout=None)
+                super().__init__()
                 self.outer = outer
                 self.order = order
                 
@@ -367,7 +368,7 @@ class Onboarding(CustomView):
 
         class FinishedView(CustomView):
             def __init__(self, outer):
-                super().__init__(timeout=None)
+                super().__init__()
                 self.outer = outer
                 
                 self.back_btn = nextcord.ui.Button(label="Back", style=nextcord.ButtonStyle.danger)

--- a/src/features/options_menu/ban_button.py
+++ b/src/features/options_menu/ban_button.py
@@ -62,7 +62,7 @@ class BanButton(OptionsButton):
             
     class BanView(CustomView):
         def __init__(self, outer, parent, message: nextcord.Message):
-            super().__init__(timeout = None)
+            super().__init__()
             self.outer = outer
             self.parent = parent
             self.message = message

--- a/src/features/options_menu/editing/embeds.py
+++ b/src/features/options_menu/editing/embeds.py
@@ -8,7 +8,7 @@ from features.action_logging import trigger_edit_log
 
 class EditEmbed(CustomView):
     def __init__(self, message_id: int):
-        super().__init__(timeout = None)
+        super().__init__()
         self.message_id = message_id
         
     async def load_buttons(self, interaction: Interaction):
@@ -107,7 +107,7 @@ class EditEmbed(CustomView):
                 for option in utils.COLOR_OPTIONS:
                     select_options.append(nextcord.SelectOption(label=option, value=option, default=(option is original_color)))
                 
-                self.select = nextcord.ui.Select(placeholder="Choose a color", options=select_options)
+                self.select = nextcord.ui.Select(custom_id="edit_embed_color_select", placeholder="Choose a color", options=select_options)
                 
                 self.backBtn = nextcord.ui.Button(label="Back", style=nextcord.ButtonStyle.gray)
                 self.backBtn.callback = self.back_callback

--- a/src/features/options_menu/editing/reaction_roles.py
+++ b/src/features/options_menu/editing/reaction_roles.py
@@ -11,7 +11,7 @@ from features.action_logging import trigger_edit_log
 
 class EditReactionRole(CustomView):
     def __init__(self, message_id: int):
-        super().__init__(timeout=None)
+        super().__init__()
         self.message_id = message_id
         
     async def load_buttons(self, interaction: Interaction):
@@ -110,7 +110,7 @@ class EditReactionRole(CustomView):
         
         class EditOptionsView(CustomView):
             def __init__(self, outer, message_info):
-                super().__init__(timeout=None)
+                super().__init__()
                 self.outer = outer
                 self.message_info = message_info
                 self.added_reactions__emojis = []
@@ -345,7 +345,7 @@ class EditReactionRole(CustomView):
 
                 class EmojiSelectView(CustomView):
                     def __init__(self, outer, selection):
-                        super().__init__(timeout = None)
+                        super().__init__()
                         self.outer = outer
                         self.selection = selection
                         

--- a/src/features/options_menu/editing/role_messages.py
+++ b/src/features/options_menu/editing/role_messages.py
@@ -12,7 +12,7 @@ RoleSelectWizardView = RoleMessageSetup.GetStartedButton.Modal.RoleSelectWizardV
 
 class EditRoleMessage(CustomView):
     def __init__(self, message_id: int):
-        super().__init__(timeout=None)
+        super().__init__()
         self.message_id = message_id
         self.guild = None # Unset until load
         
@@ -81,6 +81,7 @@ class EditRoleMessage(CustomView):
                     ))
                 
                 self.select = nextcord.ui.Select(
+                    custom_id="edit_role_message_color_select",
                     placeholder="Choose a color",
                     options=select_options
                 )
@@ -147,7 +148,7 @@ class EditRoleMessage(CustomView):
             
         class AddView(CustomView):
             def __init__(self, outer, options, index=None):
-                super().__init__(timeout=None)
+                super().__init__()
                 self.outer = outer
                 self.options = options
                 self.index = index
@@ -308,7 +309,7 @@ class EditRoleMessage(CustomView):
                 
             class OptionTitleAndDescriptionModal(CustomModal):
                 def __init__(self, outer):
-                    super().__init__(title="Option Settings", timeout=None)
+                    super().__init__(title="Option Settings")
                     self.outer = outer
 
                     if self.outer.title is None:
@@ -483,7 +484,7 @@ class EditRoleMessage(CustomView):
             
         class MultiOrSingleSelectView(CustomView):
             def __init__(self, outer):
-                super().__init__(timeout=None)
+                super().__init__()
                 self.outer = outer
                 
                 options = [
@@ -502,6 +503,7 @@ class EditRoleMessage(CustomView):
                 ]
                 
                 self.select = nextcord.ui.Select(
+                    custom_id="edit_role_message_mode_select",
                     options=options,
                     placeholder="Choose a Mode"
                 )

--- a/src/features/options_menu/entrypoint_ui.py
+++ b/src/features/options_menu/entrypoint_ui.py
@@ -14,7 +14,7 @@ from config.server import Server
 
 class OptionsView(ui_components.CustomView):
     def __init__(self, interaction: Interaction, has_config_perms: bool, buttons: list, relevant_object: (nextcord.Message | nextcord.Member)):
-        super().__init__(timeout = None)
+        super().__init__()
         self.interaction = interaction
         self.has_config_perms = has_config_perms
         

--- a/src/features/profile.py
+++ b/src/features/profile.py
@@ -11,7 +11,7 @@ class Profile(CustomView):
     View for the profile command.
     """
     def __init__(self):
-        super().__init__(timeout = None)
+        super().__init__()
         
         level_card_btn = self.LevelCardButton(self)
         self.add_item(level_card_btn)
@@ -49,7 +49,7 @@ class Profile(CustomView):
             
         class LevelCardView(CustomView):
             def __init__(self, outer, interaction: Interaction):
-                super().__init__(timeout = None)
+                super().__init__()
                 self.outer = outer
                 
                 member = Member(interaction.user.id)
@@ -107,7 +107,7 @@ class Profile(CustomView):
                     
                 class ChangeTextModal(CustomModal):
                     def __init__(self, outer, interaction: Interaction):
-                        super().__init__(title = "Level-Up Card", timeout = None)
+                        super().__init__(title = "Level-Up Card")
                         self.outer = outer
                         
                         member = Member(interaction.user.id)
@@ -144,7 +144,7 @@ class Profile(CustomView):
                     
                 class ChangeColorView(CustomView):
                     def __init__(self, outer, interaction: Interaction):
-                        super().__init__(timeout = None)
+                        super().__init__()
                         self.outer = outer
                         
                         options = ["Red", "Green", "Blue", "Yellow", "White", "Blurple", "Greyple", "Teal", "Purple", "Gold", "Magenta", "Fuchsia"]
@@ -155,7 +155,7 @@ class Profile(CustomView):
                         for option in options:
                             select_options.append(nextcord.SelectOption(label = option, value = option, default = (option == member.level_up_card_embed["color"])))
                                 
-                        self.select = nextcord.ui.Select(options = select_options, placeholder = "Select a Color")
+                        self.select = nextcord.ui.Select(custom_id="level_card_color_select", options = select_options, placeholder = "Select a Color")
                         self.add_item(self.select)
                         
                         back_btn = nextcord.ui.Button(label = "Back", style = nextcord.ButtonStyle.danger, row = 1)
@@ -208,7 +208,7 @@ class Profile(CustomView):
                     
                 class EnableDisableView(CustomView):
                     def __init__(self, outer, enabled):
-                        super().__init__(timeout = None)
+                        super().__init__()
                         self.outer = outer
                         self.enabled = enabled
                         
@@ -268,7 +268,7 @@ class Profile(CustomView):
             
         class JoinCardView(CustomView):
             def __init__(self, outer, interaction: Interaction):
-                super().__init__(timeout = None)
+                super().__init__()
                 self.outer = outer
                 
                 member = Member(interaction.user.id)
@@ -326,7 +326,7 @@ class Profile(CustomView):
                     
                 class ChangeTextModal(CustomModal):
                     def __init__(self, outer, interaction: Interaction):
-                        super().__init__(title = "Join Card", timeout = None)
+                        super().__init__(title = "Join Card")
                         self.outer = outer
                         
                         member = Member(interaction.user.id)
@@ -363,7 +363,7 @@ class Profile(CustomView):
                     
                 class ChangeColorView(CustomView):
                     def __init__(self, outer, interaction: Interaction):
-                        super().__init__(timeout = None)
+                        super().__init__()
                         self.outer = outer
                         
                         options = ["Red", "Green", "Blue", "Yellow", "White", "Blurple", "Greyple", "Teal", "Purple", "Gold", "Magenta", "Fuchsia"]
@@ -374,7 +374,7 @@ class Profile(CustomView):
                         for option in options:
                             select_options.append(nextcord.SelectOption(label = option, value = option, default = (option == member.join_card_embed["color"])))
                                 
-                        self.select = nextcord.ui.Select(options = select_options, placeholder = "Select a Color")
+                        self.select = nextcord.ui.Select(custom_id="join_card_color_select", options = select_options, placeholder = "Select a Color")
                         self.add_item(self.select)
                         
                         back_btn = nextcord.ui.Button(label = "Back", style = nextcord.ButtonStyle.danger, row = 1)
@@ -427,7 +427,7 @@ class Profile(CustomView):
                     
                 class EnableDisableView(CustomView):
                     def __init__(self, outer, enabled):
-                        super().__init__(timeout = None)
+                        super().__init__()
                         self.outer = outer
                         self.enabled = enabled
                         
@@ -487,7 +487,7 @@ class Profile(CustomView):
             
         class SettingsView(CustomView):
             def __init__(self, outer):
-                super().__init__(timeout = None)
+                super().__init__()
                 self.outer = outer
                 
                 dms_btn = self.DmsButton(self)
@@ -528,7 +528,7 @@ class Profile(CustomView):
         
                 class DmsView(CustomView):
                     def __init__(self, outer, interaction: Interaction):
-                        super().__init__(timeout = None)
+                        super().__init__()
                         self.outer = outer
                         
                         backBtn = nextcord.ui.Button(label = "Back", style = nextcord.ButtonStyle.danger)
@@ -582,7 +582,7 @@ class Profile(CustomView):
                     
                 class DataView(CustomView):
                     def __init__(self, outer):
-                        super().__init__(timeout = None)
+                        super().__init__()
                         self.outer = outer
                         
                         backBtn = nextcord.ui.Button(label = "Back", style = nextcord.ButtonStyle.danger)

--- a/src/features/purging.py
+++ b/src/features/purging.py
@@ -22,7 +22,7 @@ class ConfirmationView(ui_components.CustomView):
     """
     
     def __init__(self):
-        super().__init__(timeout=None)
+        super().__init__()
         self.choice = None
 
         # Create Cancel button

--- a/src/features/reaction_roles.py
+++ b/src/features/reaction_roles.py
@@ -47,7 +47,7 @@ class ReactionRoleView(ui_components.CustomView):
         else:
             max_values = 10
         
-        self.select = nextcord.ui.Select(placeholder="Select Up to 10 Roles", options=options, max_values=max_values)
+        self.select = nextcord.ui.Select(custom_id="reaction_role_select", placeholder="Select Up to 10 Roles", options=options, max_values=max_values)
         
         self.button = nextcord.ui.Button(label="Create", style=nextcord.ButtonStyle.blurple)
         self.button.callback = self.create_callback

--- a/src/features/role_messages.py
+++ b/src/features/role_messages.py
@@ -12,7 +12,7 @@ class RoleMessageButton_Single(CustomView):
     
     class View(CustomView):
         def __init__(self, user: nextcord.Member, message: nextcord.Message):
-            super().__init__(timeout = None)
+            super().__init__()
             self.message = message
             self.available_roles = []
             
@@ -47,7 +47,7 @@ class RoleMessageButton_Single(CustomView):
                 
                 options.append(nextcord.SelectOption(label=name, description=description, value="|".join(roles), default=selected))
                 
-            self.select = nextcord.ui.Select(placeholder="Choose a Role", min_values=0, options=options)
+            self.select = nextcord.ui.Select(custom_id="role_message_single_select", placeholder="Choose a Role", min_values=0, options=options)
             self.select.callback = self.select_callback
             self.add_item(self.select)
                 
@@ -103,7 +103,7 @@ class RoleMessageButton_Multiple(CustomView):
     
     class View(CustomView):
         def __init__(self, user: nextcord.Member, message: nextcord.Message):
-            super().__init__(timeout = None)
+            super().__init__()
             self.message = message
             self.available_roles = []
             
@@ -135,7 +135,7 @@ class RoleMessageButton_Multiple(CustomView):
                 
                 options.append(nextcord.SelectOption(label=name, description=description, value="|".join(roles), default=selected))
                 
-            self.select = nextcord.ui.Select(placeholder="Choose Roles", min_values=0, max_values=len(options), options=options)
+            self.select = nextcord.ui.Select(custom_id="role_message_multi_select", placeholder="Choose Roles", min_values=0, max_values=len(options), options=options)
             self.select.callback = self.select_callback
             self.add_item(self.select)
                 
@@ -191,7 +191,7 @@ class RoleMessageButton_Multiple(CustomView):
 
 class RoleMessageSetup(CustomView):
     def __init__(self):
-        super().__init__(timeout = None)
+        super().__init__()
 
         link_button = nextcord.ui.Button(
             label="Learn More",
@@ -241,7 +241,7 @@ class RoleMessageSetup(CustomView):
             
         class Modal(CustomModal):
             def __init__(self):
-                super().__init__(title = "Role Message Creation Wizard", timeout = None)
+                super().__init__(title = "Role Message Creation Wizard")
                 
                 self.title_input = nextcord.ui.TextInput(label="To begin, please add a Title", max_length=256)
                 self.add_item(self.title_input)
@@ -254,7 +254,7 @@ class RoleMessageSetup(CustomView):
                 
             class RoleSelectWizardView(CustomView):
                 def __init__(self, title, description):
-                    super().__init__(timeout = None)
+                    super().__init__()
                     self.title = title
                     self.description = description
                     self.color = nextcord.Color.teal()
@@ -324,8 +324,8 @@ class RoleMessageSetup(CustomView):
                             for option in utils.COLOR_OPTIONS:
                                 select_options.append(nextcord.SelectOption(label=option, value=option, default=(option is original_color)))
                             
-                            self.select = nextcord.ui.Select(placeholder="Choose a color", options=select_options)
-                            
+                            self.select = nextcord.ui.Select(custom_id="role_message_edit_color_select", placeholder="Choose a color", options=select_options)
+
                             self.back_btn = nextcord.ui.Button(label="Back", style=nextcord.ButtonStyle.gray)
                             self.back_btn.callback = self.back_callback
 
@@ -374,7 +374,7 @@ class RoleMessageSetup(CustomView):
                         
                     class AddView(CustomView):
                         def __init__(self, outer, options, index = None):
-                            super().__init__(timeout = None)
+                            super().__init__()
                             self.outer = outer
                             self.options = options
                             self.index = index
@@ -516,7 +516,7 @@ class RoleMessageSetup(CustomView):
                             
                         class OptionTitleAndDescriptionModal(CustomModal):
                             def __init__(self, outer):
-                                super().__init__(title = "Option Settings", timeout = None)
+                                super().__init__(title = "Option Settings")
                                 self.outer = outer
 
                                 if self.outer.title == None:
@@ -645,7 +645,7 @@ class RoleMessageSetup(CustomView):
                         
                     class MultiOrSingleSelectView(CustomView):
                         def __init__(self, outer):
-                            super().__init__(timeout = None)
+                            super().__init__()
                             self.outer = outer
                             
                             options = [
@@ -661,6 +661,7 @@ class RoleMessageSetup(CustomView):
                                 )
                             ]
                             self.select = nextcord.ui.Select(
+                                custom_id="role_message_mode_select",
                                 options=options,
                                 placeholder="Choose a Mode"
                             )

--- a/src/modules/custom_types.py
+++ b/src/modules/custom_types.py
@@ -57,6 +57,12 @@ class ExpiringSet:
             # Overwriting the timestamp effectively "renews" the item
             self.store[item] = time.time() + self.expiration_time
 
+    def remove(self, item):
+        """Removes an item if present."""
+        with self.lock:
+            self._purge_expired()
+            self.store.pop(item, None)
+
     def __contains__(self, item):
         with self.lock:
             self._purge_expired()


### PR DESCRIPTION
- View/modal leak: audited every View/Modal subclass in src/ and gave per-interaction ones a finite timeout instead of `timeout=None` (which nextcord never evicts from its internal stores without one). CustomView and CustomModal now default to a shared VIEW_TIMEOUT (5 min, src/config/global_settings.py) instead of each subclass hardcoding its own value. The 10 views registered once via bot.add_view() in init_views() correctly keep timeout=None; 7 decorative link-only views in ui_components.py were left alone (no dispatchable items, so they never populate nextcord's view store regardless of timeout).
- Startup chunking: set chunk_guilds_at_startup=False and deleted ensure_guilds_ready() outright, since retrying full-guild REST chunking after boot would have silently reintroduced the same boot-time cost. Moved on_member_remove to on_raw_member_remove (always dispatched, unlike the cache-gated original), refactoring autobans.member_has_autoban, leveling.handle_member_removal, and join_leave_messages.trigger_leave_message to take guild/IDs directly since the raw event only provides a nextcord.User, not a Member. Removed four runtime guild.chunk() calls that would have re-chunked guilds on the message-edit/delete and member-removal/nickname-check hot paths, defeating the point of disabling startup chunking.
- Correctness follow-ups needed to make the above safe: resolve an edited message's author via a single-member lookup (cache hit or REST fetch-on-miss) before the profanity check, since it can now be a plain User; implemented ExpiringSet.remove() since the method was incorrectly used in the codebase, and it is a reasonable inclusion.
- Fixed a bug found while testing this against a live bot, unrelated to the plan above but blocking verification: nextcord 3.2.0 broke every nextcord.ui.Select's custom_id auto-generation (fixed by passing custom_id explicitly at all 14 call sites).
- Added Active Views/Modals, chunked-guild count, and cached member/user/message counts to the `-memory` admin command (src/components/memory_profiler.py) as the verification metric the assessment doc calls for; the active-vs-raw-store distinction matters because nextcord only sweeps timed-out entries as a side effect of other view activity, not on a timer.
- documentation/scale_performance_assessment_2026-07.md updated throughout to mark items 2 & 3 done and record all of the above.

Full test suite passes (33/33). Reviewed across three passes (in-repo, GitHub Copilot, live-crash triage) with fixes applied for each.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com> for monotonous changes.
All code reviewed by myself and Claude Fable 5.