### PR TITLE
fix(deps): bump json and concurrent-ruby to patch Dependabot security alerts

### DIFF
--- a/github-pages-site/Gemfile.lock
+++ b/github-pages-site/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
     base64 (0.3.0)
     bigdecimal (4.1.2)
     colorator (1.1.0)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     csv (3.3.5)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
@@ -57,7 +57,7 @@ GEM
       jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.18.1)
+    json (2.21.1)
     just-the-docs (0.12.0)
       jekyll (>= 3.8.5)
       jekyll-include-cache


### PR DESCRIPTION
## Summary

Resolves all 4 open Dependabot security alerts, all in `github-pages-site/Gemfile.lock`:

| Gem | From | To | Alerts |
|---|---|---|---|
| `json` | 2.18.1 | 2.21.1 | #16 (high) — format string injection, patched ≥ 2.19.2 |
| `concurrent-ruby` | 1.3.6 | 1.3.7 | #14 (high) — `AtomicReference#update` NaN livelock; #13, #15 (low) — read/write lock accounting bugs |

Lockfile-only change generated with `bundle lock --update json concurrent-ruby`; both versions satisfy the existing Gemfile constraints (`json ~> 2.6`, `concurrent-ruby ~> 1.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)